### PR TITLE
Fix magnet url

### DIFF
--- a/bot/telegram.go
+++ b/bot/telegram.go
@@ -164,6 +164,8 @@ func handleDownload(b *Bot, updates <-chan tgbotapi.Update, chatID int64, transm
 	torrentID, err := transmission.StartDownload(fileLink, downloadPath)
 	if err != nil {
 		log.Println("Error starting download:", err)
+		startMsg := tgbotapi.NewMessage(chatID, "There is a error in the torrent/magnet")
+		b.BotAPI.Send(startMsg)
 		return
 	}
 

--- a/transmission/client.go
+++ b/transmission/client.go
@@ -35,7 +35,7 @@ func (c *Client) StartDownload(magnetLink, downloadPath string) (int64, error) {
 	var torrentId *int64
 
 	if c.ChecksMagnetURL(magnetLink) {
-		response, err := c.Client.TorrentAdd(&transmissionrpc.TorrentAddPayload{Filename: &magnetLink})
+		response, err := c.Client.TorrentAdd(&transmissionrpc.TorrentAddPayload{Filename: &magnetLink, DownloadDir: &downloadPath})
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			return 0, err

--- a/transmission/client.go
+++ b/transmission/client.go
@@ -1,6 +1,10 @@
 package transmission
 
 import (
+	"fmt"
+	"os"
+	"strings"
+
 	"github.com/Coolknight/transmission-telegram-bot/config"
 	"github.com/hekmon/transmissionrpc"
 )
@@ -27,14 +31,30 @@ func NewClient(config config.Transmission) (*Client, error) {
 
 // StartDownload starts a download using the Transmission client
 func (c *Client) StartDownload(magnetLink, downloadPath string) (int64, error) {
-	response, err := c.Client.TorrentAddFileDownloadDir(magnetLink, downloadPath)
-	if err != nil {
-		return 0, err
-	}
 
-	// Extract and return the torrent ID
-	torrentID := response.ID // Assuming only one torrent is added
-	return *torrentID, nil
+	var torrentId *int64
+
+	if c.ChecksMagnetURL(magnetLink) {
+		response, err := c.Client.TorrentAdd(&transmissionrpc.TorrentAddPayload{Filename: &magnetLink})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 0, err
+		} else {
+			// Only 3 fields will be returned/set in the Torrent struct
+			fmt.Println("Added: " + *response.Name)
+			torrentId = response.ID
+			return *torrentId, nil
+		}
+
+	} else {
+		response, err := c.Client.TorrentAddFileDownloadDir(magnetLink, downloadPath)
+		if err != nil {
+			return 0, err
+		}
+		fmt.Println("Added: " + *response.Name)
+		torrentId = response.ID // Assuming only one torrent is added
+		return *torrentId, nil
+	}
 }
 
 // IsDownloadComplete checks if the specified torrent download is complete
@@ -66,4 +86,14 @@ func (c *Client) GetName(torrentID int64) (string, error) {
 	name := torrents[0].Name
 
 	return *name, nil // Handle the case when no torrents or multiple torrents are returned
+}
+
+// ChecksMagnetURL checks if the specified torrent URL is a magnet
+func (c *Client) ChecksMagnetURL(torrentURL string) bool {
+
+	if strings.Split(torrentURL, ":")[0] == "magnet" {
+		return true
+	} else {
+		return false
+	}
 }


### PR DESCRIPTION
Hi @Coolknight , last month I tried to add a torrent by pasting magnet URL but I encountered errors that makes crash the bot.
I did a small research and I found that the used function from the API, when you pass a file encodes it to a base64 file and when you pass an URL does the same and throws an error.
With my implementation I made a small function that takes the string and checks if it's a magnet, when it's a magnets uses another function that it doesn't encode the URL.
